### PR TITLE
log link to the server instead of just the port

### DIFF
--- a/apps/api-server.js
+++ b/apps/api-server.js
@@ -28,5 +28,5 @@ routes.setup(app);
 app.get('/', function(req, res) { res.redirect('/gallery'); });
 
 var server = app.listen(process.env.PORT || 55555, function() {
-  console.log('API server listening on port %d', server.address().port);
+  console.log('API server listening on http://localhost:%d', server.address().port);
 });


### PR DESCRIPTION
I know I'm being lazy to type the whole thing, but having this
log as URL is good especially using iTerm I can take advantage of
Smart click where I can do `cmd`+ click and it will open the link
to the page right away :)